### PR TITLE
Update sdbPricer.user.js

### DIFF
--- a/userscripts/sdbPricer.user.js
+++ b/userscripts/sdbPricer.user.js
@@ -62,25 +62,34 @@
 
       let priceStr = '';
 
-      if(!item || (item && item.status !== 'no trade' && !item.price.value && !item.isNC)){
-        priceStr = `<a href="https://itemdb.com.br/item/${item.slug}" target="_blank">???</a></small>`;
-      }
-
-      if(item && item.status === 'no trade'){
-        priceStr = `<a href="https://itemdb.com.br/item/${item.slug}" target="_blank">No Trade</a></small>`;
-      }
-
-      if(item && item.isNC){
-        priceStr = `<a href="https://itemdb.com.br/item/${item.slug}" target="_blank">NC</a>`;
-      }
-
-      if(item && item.price.value){
-        priceStr = `<a href="https://itemdb.com.br/item/${item.slug}" target="_blank">${intl.format(item.price.value)} NP</a>`;
-      }
-      
-      if (item && item.isMissingInfo){
+      /*
+       * If items are missing from the DB, wrap the conditions inside a try -> catch.
+       * With this approach, the execution of the script is not interrupted in case an "item.slug" is not parseable.
+       * This error happened specifically with the item "Chomby Transmogrification Potion".
+       */
+      try {
+        if(!item || (item && item.status !== 'no trade' && !item.price.value && !item.isNC)){
+          priceStr = `<a href="https://itemdb.com.br/item/${item.slug}" target="_blank">???</a></small>`;
+        }
+  
+        if(item && item.status === 'no trade'){
+          priceStr = `<a href="https://itemdb.com.br/item/${item.slug}" target="_blank">No Trade</a></small>`;
+        }
+  
+        if(item && item.isNC){
+          priceStr = `<a href="https://itemdb.com.br/item/${item.slug}" target="_blank">NC</a>`;
+        }
+  
+        if(item && item.price.value){
+          priceStr = `<a href="https://itemdb.com.br/item/${item.slug}" target="_blank">≈ ${intl.format(item.price.value)} NP</a>`;
+        }
+        
+        if (item && item.isMissingInfo){
+          priceStr += `<br/><small><a href="https://itemdb.com.br/contribute" target="_blank"><i>We need info about this item<br/>Learn how to Help</i></a></small>`
+        }
+      } catch { // We're not catching any specific error, as any error that may surface it will be handled with the "We need more info" referral link.
+        priceStr = `<a>Not Found</a></small>`;
         priceStr += `<br/><small><a href="https://itemdb.com.br/contribute" target="_blank"><i>We need info about this item<br/>Learn how to Help</i></a></small>`
-
       }
 
       tds.eq( -2 ).before(`<td align="center" noWrap>${priceStr}</td>`);


### PR DESCRIPTION
Whenever an item is not present in the database page, the execution of the script will be stopped because the "item.slug" reference is null. Leading the SDB pricing to a hault for the specific page where it finds said error.

I have wrapped the conditions for the "item.slug" inside a try / catch block of code. The catch is only used to parse the "priceStr" variable to be read and injected in the SDB GUI, instead of the null value trying to be read by the original code.

This error happened specifically with a Chomby Transmogrification Potion.

In case you have any questions let me know. I will be using a modified version of this script in my NeoBuyer+ extension with the credit that you deserve.  This is an amazing project and repository, so thank you so much for you hard work!