### PR TITLE
Adding rarity text for artifact (r200)

### DIFF
--- a/userscripts/albumHelper.user.js
+++ b/userscripts/albumHelper.user.js
@@ -201,6 +201,7 @@ function createInfoContent(imgElement, itemData) {
         else if (rNum >= 105 && rNum <= 110) return `<strong style="color:red">r${r} (MEGA RARE)</strong>`;
         else if (rNum >= 111 && rNum <= 179) return `<strong style="color:red">r${r} (RARITY ${rNum})</strong>`;
         else if (rNum === 180) return `<strong style="color:#666666">r${r} (retired)</strong>`;
+        else if (rNum === 200) return `<strong style="color:red">r${r} (Artifact - 200)</strong>`;
     };
 
     const createHelper = itemName => {

--- a/userscripts/albumHelper.user.js
+++ b/userscripts/albumHelper.user.js
@@ -1,10 +1,9 @@
 // ==UserScript==
 // @name         itemdb - Stamp Album Helper
-// @version      1.0.0
+// @version      1.0.1
 // @author       originally EatWooloos, updated by itemdb
 // @namespace    itemdb
 // @description  Adds an info menu about your missing stamps
-// @version      1.0.0
 // @icon         https://itemdb.com.br/favicon.ico
 // @match        *://*.neopets.com/stamps.phtml?type=album&page_id=*
 // @connect      itemdb.com.br


### PR DESCRIPTION
Updating the `rarityText` function to return styling for stamps with r200; styled to match [JellyNeo](https://www.jellyneo.net/?go=item_rarities_explained). This currently just impacts the "Neopets 22nd Birthday Stamp".

Before:
<img width="352" alt="image" src="https://github.com/user-attachments/assets/2ef7ad75-7468-4720-80ff-956e579a9f40" />

After:
<img width="359" alt="image" src="https://github.com/user-attachments/assets/73449d2a-2ff5-497d-8827-00cf1f956a8f" />
