### PR TITLE
feat: add support for shop stock pages

### DIFF
--- a/userscripts/sdbPricer.user.js
+++ b/userscripts/sdbPricer.user.js
@@ -1,6 +1,6 @@
   // ==UserScript==
   // @name         itemdb - Safety Deposit Box Pricer
-  // @version      1.5.3
+  // @version      1.6.0
   // @author       itemdb
   // @namespace    itemdb
   // @description  Shows the market price for your sdb/closet items
@@ -8,6 +8,8 @@
   // @match        *://*.itemdb.com.br/*
   // @match        *://*.neopets.com/safetydeposit.phtml*
   // @match        *://*.neopets.com/closet.phtml*
+  // @match        *://*.neopets.com/market.phtml?type=your*
+  // @match        *://*.neopets.com/market.phtml?order_by=*
   // @icon         https://itemdb.com.br/favicon.ico
   // @connect      itemdb.com.br
   // @grant        GM_xmlhttpRequest
@@ -27,13 +29,19 @@ const script_info = {
 unsafeWindow.itemdb_sdbPricer = script_info;
 
 async function fetchPriceData(){
-  const trs = $('form table').eq(2).find('tr').slice(1, -1);
+  let trs;
+  if (isSafetyDeposit || isCloset) trs = $('form table').eq(2).find('tr').slice(1, -1);
+  if (isUserShop && hasPin) trs = $('form[action="process_market.phtml"]').find('tr').slice(1, -3);
+  else if (isUserShop) trs = $('form[action="process_market.phtml"] table').eq(0).find('tr').slice(1, -1);
 
   const IDs = [];
 
   trs.each(function (i) {
     const tds = $(this).find('td');
-    const itemId = tds.last().find('input').attr('name').match(/\d+/)?.[0] ?? tds.last().find('input').data('item_id')
+
+    let itemId;
+    if (isSafetyDeposit || isCloset) itemId = tds.last().find('input').attr('name')?.match(/\d+/)?.[0] ?? tds.last().find('input').data('item_id');
+    if (isUserShop) itemId = tds.last().find('input').attr('name')?.match(/\d+/)?.[0] ?? tds.last().find('select').attr('name')?.match(/\d+/)?.[0];
 
     IDs.push(itemId);
   });
@@ -59,26 +67,59 @@ async function fetchPriceData(){
 }
 
 async function pricePage(itemData) {
-  const trs = $('form table').eq(2).find('tr').slice(1, -1);
+  let trs;
+  if (isSafetyDeposit || isCloset) trs = $('form table').eq(2).find('tr').slice(1, -1);
+  else if (isUserShop && hasPin) trs = $('form[action="process_market.phtml"]').find('tr').slice(1, -3);
+  else if (isUserShop) trs = $('form[action="process_market.phtml"] table').eq(0).find('tr').slice(1, -1);
 
-  let headingSelector = '.content > form > table:nth-child(3) > tbody > tr:nth-child(1) > td:nth-last-child(2)';
-  if(URLHas('closet')) headingSelector = "form[action='process_closet.phtml'] th:nth-of-type(5)";
+  if (isSafetyDeposit) $('.content > form > table:nth-child(3) > tbody > tr:nth-child(1) > td:nth-last-child(4)').css('width', '200px');
+  else if (isCloset) $('form[action="process_closet.phtml"] th:nth-of-type(3)').css('width', '200px');
 
-  $(headingSelector)
-  .before('<td align="center" class="contentModuleHeaderAlt" style="text-align: center; width: 70px;" noWrap><img src="https://itemdb.com.br/logo_icon.svg" style="vertical-align: middle;" width="25px" height="auto"/> <b>Price</b></td>');
+  let itemdbHeader;
+  if (isSafetyDeposit || isCloset) itemdbHeader = '<td align="center" class="contentModuleHeaderAlt" style="text-align: center; width: 70px;" noWrap><img src="https://itemdb.com.br/logo_icon.svg" style="vertical-align: middle;" width="25px" height="auto"/> <b>Price</b></td>';
+  else if (isUserShop) itemdbHeader = '<td align="center" bgcolor="#dddd77" style="text-align: center; width: 70px;" noWrap><img src="https://itemdb.com.br/logo_icon.svg" style="vertical-align: middle;" width="25px" height="auto"/> <b>Price</b><br><small style="color: #000000"><b>Use at your own risk!</b></small></td>';
 
-  let footerSelector = '.content > form > table:nth-child(3) > tbody > tr:last-child > td';
-  if(URLHas('closet')) footerSelector = "form[action='process_closet.phtml'] tbody tr:last-of-type td"
+  let headingSelector;
+  if (isSafetyDeposit) headingSelector = '.content > form > table:nth-child(3) > tbody > tr:nth-child(1) > td:nth-last-child(2)';
+  else if (isCloset) headingSelector = 'form[action="process_closet.phtml"] th:nth-of-type(5)';
+  else if (isUserShop) headingSelector = 'form[action="process_market.phtml"] > table > tbody > tr:nth-child(1) > td:nth-child(5)';
 
-  $(footerSelector).before("<td></td>");
+  $(headingSelector).before(itemdbHeader);
+
+  let footerSelector;
+  if (isSafetyDeposit) footerSelector = '.content > form > table:nth-child(3) > tbody > tr:last-child > td';
+  else if (isCloset) footerSelector = 'form[action="process_closet.phtml"] tbody tr:last-of-type td';
+  else if (isUserShop) footerSelector = 'form[action="process_market.phtml"] > table > tbody > tr:last-child td';
+
+  if (isSafetyDeposit || isCloset) $(footerSelector).before("<td></td>");
+  else if (isUserShop) {
+    $(footerSelector)[0].colSpan = 8;
+    if (hasPin) {
+      $(footerSelector).parent().prev().find('td')[0].colSpan = 8;
+    }
+  }
+
+  const timeOptions = {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+    timeZoneName: 'short'
+  }
 
   const intl = new Intl.NumberFormat();
 
-  let grandTotal = 0
+  let grandTotal = 0;
+  let userGrandTotal = 0;
 
   trs.each(function (i) {
     const tds = $(this).find('td');
-    const itemId = tds.last().find('input').attr('name').match(/\d+/)?.[0] ?? tds.last().find('input').data('item_id');
+
+    let itemId;
+    if (isSafetyDeposit || isCloset) itemId = tds.last().find('input').attr('name')?.match(/\d+/)?.[0] ?? tds.last().find('input').data('item_id');
+    else if (isUserShop) itemId = tds.last().find('input').attr('name')?.match(/\d+/)?.[0] ?? tds.last().find('select').attr('name')?.match(/\d+/)?.[0];
 
     const item = itemData[itemId];
     let priceStr = '<div style="display: flex;flex-flow: column;justify-content: center;align-items: center; gap: .3rem;">';
@@ -105,7 +146,7 @@ async function pricePage(itemData) {
       }
 
       if(item.isNC && item.ncValue){
-        priceStr += `<a href="https://itemdb.com.br/item/${item.slug}?utm_content=sdbPricer" target="_blank">${item.ncValue.range} caps</a>`;
+        priceStr += `<a href="https://itemdb.com.br/item/${item.slug}?utm_content=sdbPricer" target="_blank" title="${item.ncValue.addedAt ? new Date(item.ncValue.addedAt).toLocaleString(undefined, timeOptions) : ''}">${item.ncValue.range} ${item.ncValue.range == 1 ? 'cap' : 'caps'}</a>`;
       }
 
       if(item && item.status !== 'no trade' && !item.price.value && !item.isNC){
@@ -116,20 +157,25 @@ async function pricePage(itemData) {
         priceStr += `<div>`;
 
         if(item.saleStatus && item.saleStatus.status !== 'regular') {
-            var color2 = item.saleStatus.status === 'ets' ? 'green' : '#fb1717';
-            priceStr += `<small style='color:${color2}'><b>[${item.saleStatus.status.toUpperCase()}]</b></small> `;
+          var color2 = item.saleStatus.status === 'ets' ? 'green' : '#fb1717';
+          priceStr += `<small style='color:${color2}'><b>[${item.saleStatus.status.toUpperCase()}]</b></small> `;
         }
 
-        priceStr += `<a href="https://itemdb.com.br/item/${item.slug}?utm_content=sdbPricer" target="_blank">${item.price.inflated ? "⚠ " : ""}${intl.format(item.price.value)} NP</a>`;
+        priceStr += `<a href="https://itemdb.com.br/item/${item.slug}?utm_content=sdbPricer" target="_blank" title="${item.price.addedAt ? new Date(item.price.addedAt).toLocaleString(undefined, timeOptions) : ''}">${item.price.inflated ? "⚠ " : ""}${intl.format(item.price.value)} NP</a>`;
         priceStr += `</div>`;
 
-        const itemQtyCol = tds.eq(-2)[0];
-        const itemQty = parseInt(itemQtyCol.textContent)
-        const totalValue = item.price.value * itemQty;
-        grandTotal += totalValue
+        let itemQtyCol;
+        if (isSafetyDeposit || isCloset) itemQtyCol = tds.eq(-2)[0];
+        else if (isUserShop) itemQtyCol = tds.eq(-5)[0];
 
-        if (itemQty > 1){
-            priceStr += `<small style='color: #000000'><b>${intl.format(totalValue)} NP total</b></small> `
+        const itemQty = parseInt(itemQtyCol.textContent);
+        const totalValue = item.price.value * itemQty;
+        grandTotal += totalValue;
+
+        if (isUserShop) userGrandTotal += (tds.eq(-3).find('input').attr('value') * itemQty);
+
+        if (itemQty > 1) {
+          priceStr += `<small style='color: #000000'><b>${intl.format(totalValue)} NP total</b></small>`;
         }
       }
 
@@ -143,20 +189,42 @@ async function pricePage(itemData) {
     }
 
     priceStr += '</div>';
-    tds.eq( -2 ).before(`<td align="center" width="150px">${priceStr}</td>`);
+
+    if (isSafetyDeposit) tds.eq(-3).css('text-align', 'center');
+    else if (isUserShop) tds.eq(-4).css('text-align', 'center');
+
+    if (isSafetyDeposit) tds.eq(-4).css('width', '200px');
+
+    if (isSafetyDeposit || isCloset) tds.eq(-2).before(`<td align="center" width="150px">${priceStr}</td>`);
+    else if (isUserShop) tds.eq(-3).before(`<td align="center" bgcolor="#ffffcc" width="150px">${priceStr}</td>`);
+
   })
 
-    $(footerSelector).parent().before(`
-<tr bgcolor="silver">
-  <th colspan="3" class="contentModuleHeaderAlt" style="text-align: center;"></th>
-  <th class="contentModuleHeaderAlt" style="text-align: right;">Total:</th>
-  <td align="center" class="contentModuleHeaderAlt" style="text-align: center; width: 70px;" nowrap="">
-    <b>${intl.format(grandTotal)} NP</b>
-  </td>
-  <th colspan="2" class="contentModuleHeaderAlt" style="text-align: center;"></th>
-</tr>
-`);
+  if (isSafetyDeposit || isCloset) {
+    $(footerSelector).parent().before(`<tr bgcolor="silver">
+                                    <th colspan="3" class="contentModuleHeaderAlt" style="text-align: center;"></th>
+                                    <th class="contentModuleHeaderAlt" style="text-align: right;">Total:</th>
+                                    <td align="center" class="contentModuleHeaderAlt" style="text-align: center; width: 70px;" nowrap="">
+                                        <b>${intl.format(grandTotal)} NP</b>
+                                    </td>
+                                    <th colspan="2" class="contentModuleHeaderAlt" style="text-align: center;"></th>
+                                    </tr>`);
+  }
 
+  if (isUserShop) {
+    const totalFooter = `<tr><td align="center" bgcolor="#dddd77" colspan="3"></td>
+                            <td bgcolor="#dddd77" style="text-align: right;"><b>Totals:</b></td>
+                            <td align="center" bgcolor="#dddd77" style="text-align: center; width: 70px;" nowrap="">
+                                <b>${intl.format(grandTotal)} NP</b>
+                            </td>
+                            <td align="center" bgcolor="#dddd77" style="text-align: center; width: 70px;" nowrap="">
+                                <b>${intl.format(userGrandTotal)} NP</b>
+                            </td>
+                            <td align="center" bgcolor="#dddd77" colspan="2"><b></b></td></tr>`;
+
+    if (hasPin) $(footerSelector).parent().prev().before(totalFooter);
+    else $(footerSelector).parent().before(totalFooter);
+  }
 }
 
 function setColor(rarity) {
@@ -170,4 +238,11 @@ function setColor(rarity) {
   return '#ec69ff';                   // Neocash | Artifact - 500
 }
 
-if (URLHas('safetydeposit') || URLHas('closet')) fetchPriceData();
+const isSafetyDeposit = URLHas('safetydeposit');
+const isCloset = URLHas('closet');
+const isUserShop = URLHas('market');
+
+let hasPin = false;
+if (isUserShop) hasPin = $('input[type="password"][name="pin"]#pin_field').length > 0;
+
+if (isSafetyDeposit || isCloset || isUserShop) fetchPriceData();


### PR DESCRIPTION
Major:
- Added support for Shop Stock page
  - Adjusted general logic for page and element detection
  - Added a warning to caution using the prices to price stock
  - Added sum for the user's own inputted prices

![image](https://github.com/user-attachments/assets/4934a055-7123-474e-95d8-34b6efb655e4)


Minor:

- Adjusted the width of the 'Description' column on Safety Deposit Box/Closet pages to reduce squishing the 'Name' column
- Centered the text of the 'Type' column on Safety Deposit Box/Shop Stock pages to be more consistent with Closet pages
- Added a title attribute to NC/NP values to display the `addedAt` value in local format on hover
- Added logic to use 'cap' instead of 'caps' when NC range = 1

![image](https://github.com/user-attachments/assets/86d55a6a-4464-4006-bb2c-70ed2ebb9f32)

